### PR TITLE
DEP Update dependencies for CMS 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "symfony/finder": "^4.0",
-        "symfony/yaml": "^4.0",
-        "marcj/topsort": "^2",
-        "psr/simple-cache": "^1.0"
+        "symfony/finder": "^4.4.44",
+        "symfony/yaml": "^4.4.44",
+        "marcj/topsort": "^2.0.0",
+        "psr/simple-cache": "^1.0.1"
     },
     "require-dev": {
         "silverstripe/framework": "^5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

This is essentially a temporary DEP change, as we're going to replace this with symfony 6

Fixes deprecated warnings on --prefer-lowest builds on php 8.1

https://github.com/silverstripe/silverstripe-framework/runs/7737424997?check_suite_focus=true
` PHP Deprecated:  Return type of Symfony\Component\Finder\Finder::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/silverstripe-framework/silverstripe-framework/vendor/symfony/finder/Finder.php on line 691`

