### PR TITLE
NEW Record deprecated config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "SilverStripe configuration based on YAML and class statics",
     "license": "BSD-3-Clause",
     "require": {
+        "php": "^7.4 || ^8.0",
         "symfony/finder": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
         "marcj/topsort": "^1 || ^2",
         "psr/simple-cache": "^1.0",
-        "php": "^7.4 || ^8.0"
+        "silverstripe/framework": "^4.12"
     },
     "require-dev": {
-        "silverstripe/framework": "^4.10",
         "phpunit/phpunit": "^9.5",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^3.5"

--- a/src/Collections/DeltaConfigCollection.php
+++ b/src/Collections/DeltaConfigCollection.php
@@ -270,6 +270,11 @@ class DeltaConfigCollection extends MemoryConfigCollection
      */
     protected function addDelta($class, $delta)
     {
+        if (is_array($delta['config'] ?? null)) {
+            foreach (array_keys($delta['config']) as $configKey) {
+                $this->checkForDeprecatedConfig($class, $configKey);
+            }
+        }
         $classKey = strtolower($class ?? '');
         if (!isset($this->deltas[$classKey])) {
             $this->deltas[$classKey] = [];

--- a/src/Collections/MemoryConfigCollection.php
+++ b/src/Collections/MemoryConfigCollection.php
@@ -82,6 +82,7 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface, Serial
 
         $classKey = strtolower($class ?? '');
         if ($name) {
+            $this->checkForDeprecatedConfig($classKey, $name);
             if (!isset($this->config[$classKey])) {
                 $this->config[$classKey] = [];
             }
@@ -106,9 +107,19 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface, Serial
 
         // Return either name, or whole-class config
         if ($name) {
+            $this->checkForDeprecatedConfig($class, $name);
             return isset($config[$name]) ? $config[$name] : null;
         }
         return $config;
+    }
+
+    public function checkForDeprecatedConfig($class, $name): void
+    {
+        $deprecated = $this->getClassConfig('__deprecated', true);
+        $data = $deprecated['config'][strtolower($class)][$name] ?? [];
+        if (!empty($data)) {
+            Deprecation::notice($data['version'], $data['message'], Deprecation::SCOPE_CONFIG);
+        }
     }
 
     /**

--- a/src/Transformer/YamlTransformer.php
+++ b/src/Transformer/YamlTransformer.php
@@ -9,6 +9,7 @@ use Symfony\Component\Finder\Finder;
 use MJS\TopSort\Implementations\ArraySort;
 use Exception;
 use Closure;
+use SilverStripe\Config\Collections\MemoryConfigCollection;
 
 class YamlTransformer implements TransformerInterface
 {
@@ -104,6 +105,7 @@ class YamlTransformer implements TransformerInterface
 
         foreach ($documents as $document) {
             if (!empty($document['content'])) {
+                $this->checkForDeprecatedConfig($document, $collection);
                 // We prepare the meta data
                 $metadata = $document['header'];
                 $metadata['transformer'] = static::class;
@@ -126,6 +128,21 @@ class YamlTransformer implements TransformerInterface
         }
 
         return $collection;
+    }
+
+    private function checkForDeprecatedConfig(array $document, MutableConfigCollectionInterface $collection): void
+    {
+        if (!($collection instanceof MemoryConfigCollection)) {
+            return;
+        }
+        foreach ($document['content'] as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            foreach (array_keys($value) as $valueKey) {
+                $collection->checkForDeprecatedConfig($key, $valueKey);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10543

I don't think we need to put a call to `Deprecation::notice()` in `CachedConfigCollection::get()` because it seems that `$this->getCollection()` will always return a `MemoryConfigCollection`, where `Deprecation::notice()` may be called in `get()`