### PR TITLE
API Restore nullable params

### DIFF
--- a/src/Collections/DeltaConfigCollection.php
+++ b/src/Collections/DeltaConfigCollection.php
@@ -145,9 +145,9 @@ class DeltaConfigCollection extends MemoryConfigCollection
             );
     }
 
-    public function unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        parent::__unserialize($serialized);
+        parent::__unserialize($data);
         $this->postInit();
     }
 
@@ -166,7 +166,7 @@ class DeltaConfigCollection extends MemoryConfigCollection
         $this->getDeltaMiddleware()->setCollection($this);
     }
 
-    public function set(string $class, string|null $name, mixed $data, array $metadata = []): static
+    public function set(string $class, ?string $name, mixed $data, array $metadata = []): static
     {
         // Check config to merge
         $this->clearDeltas($class, $name);
@@ -184,7 +184,7 @@ class DeltaConfigCollection extends MemoryConfigCollection
         return $this;
     }
 
-    public function remove(string $class, string|null $name): static
+    public function remove(string $class, ?string $name = null): static
     {
         // Check config to merge
         $this->clearDeltas($class, $name);

--- a/src/Collections/MemoryConfigCollection.php
+++ b/src/Collections/MemoryConfigCollection.php
@@ -75,7 +75,7 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface
         return $this;
     }
 
-    public function set(string $class, string|null $name, mixed $data, array $metadata = []): static
+    public function set(string $class, ?string $name, mixed $data, array $metadata = []): static
     {
         $this->saveMetadata($class, $metadata);
 
@@ -172,7 +172,7 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface
         return true;
     }
 
-    public function remove(string $class, string|null $name): static
+    public function remove(string $class, ?string $name = null): static
     {
         $classKey = strtolower($class ?? '');
         if ($name) {

--- a/src/Collections/MutableConfigCollectionInterface.php
+++ b/src/Collections/MutableConfigCollectionInterface.php
@@ -8,7 +8,7 @@ interface MutableConfigCollectionInterface extends ConfigCollectionInterface
      * Sets config for a given field.
      * Set name to null to set the config for the entire class.
      */
-    public function set(string $class, string $name, mixed $value, array $metadata = []): static;
+    public function set(string $class, ?string $name, mixed $value, array $metadata = []): static;
 
     /**
      * Merge a config for a class, or a field on that class
@@ -18,7 +18,7 @@ interface MutableConfigCollectionInterface extends ConfigCollectionInterface
     /**
      * Remove config for a given class, or field on that class
      */
-    public function remove(string $class, string $name): static;
+    public function remove(string $class, ?string $name = null): static;
 
     /**
      * Delete all entries

--- a/tests/Collections/DeltaConfigCollectionTest.php
+++ b/tests/Collections/DeltaConfigCollectionTest.php
@@ -122,9 +122,9 @@ class DeltaConfigCollectionTest extends TestCase
     public function testRemove()
     {
         $collection = $this->scaffoldCollection();
-        $collection->merge('First', 'key', ['value']);
-        $collection->remove('First', null);
-        $collection->merge('Second', 'string', ['bobnew']);
+        $collection->set('First', 'key', 'value');
+        $collection->remove('First');
+        $collection->set('Second', 'string', 'bobnew');
         $collection->merge('Second', 'array', ['four' => 4]);
         $collection->remove('Second', 'array');
 
@@ -144,7 +144,7 @@ class DeltaConfigCollectionTest extends TestCase
         $this->assertFalse($collection->isDeltaReset('Second')); // Only partial reset so false
         $this->assertEquals(
             [
-                'string' => ['bobnew'],
+                'string' => 'bobnew',
                 'bool' => false,
             ],
             $collection->get('Second')
@@ -152,8 +152,8 @@ class DeltaConfigCollectionTest extends TestCase
         $this->assertEquals(
             [
                 [
-                    'type' => 'merge',
-                    'config' => ['string' => ['bobnew']],
+                    'type' => 'set',
+                    'config' => ['string' => 'bobnew'],
                 ],
                 [
                     'type' => DeltaConfigCollection::REMOVE,
@@ -167,7 +167,7 @@ class DeltaConfigCollectionTest extends TestCase
     public function testClear()
     {
         $collection = $this->scaffoldCollection();
-        $collection->merge('First', 'key', ['value']);
+        $collection->set('First', 'key', 'value');
         $collection->remove('First', 'string');
         $collection->removeAll();
 

--- a/tests/Collections/MemoryConfigCollectionTest.php
+++ b/tests/Collections/MemoryConfigCollectionTest.php
@@ -17,7 +17,7 @@ class MemoryConfigCollectionTest extends TestCase
         $collection->set('test2', null, 'value');
         $this->assertTrue($collection->exists('test2'));
 
-        $collection->remove('test', null);
+        $collection->remove('test');
         $this->assertFalse($collection->exists('test'));
         $this->assertEquals([], $collection->get('test'));
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10501

Few things to tidy up the recently merged config PR linked in the issue above:
- `remove($class, $name = null)` was existing functionality to remove an entire config, not just a single key/value for a class - default null paramter has been restroed
- Refactored `string|null` to the slightly shorter `?string` syntax
- Converted a stray unserialize() method to __unserialize()
- Fixed a unit test changing merge() to set() because it was setting a non-array value

