### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/yaml": "^3.4 || ^4.0",
         "marcj/topsort": "^1 || ^2",
         "psr/simple-cache": "^1.0",
-        "silverstripe/framework": "4.13.x-dev"
+        "silverstripe/framework": "^4.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33