### PR TITLE
FIX Don't use PHP 8 syntax

### DIFF
--- a/src/Transformer/PrivateStaticTransformer.php
+++ b/src/Transformer/PrivateStaticTransformer.php
@@ -91,7 +91,7 @@ class PrivateStaticTransformer implements TransformerInterface
 
             // Detect deprecated config
             $docComment = $prop->getDocComment();
-            if (str_contains($docComment, '@deprecated')) {
+            if (strpos($docComment, '@deprecated') !== false) {
                 $propName = $prop->getName();
                 $deprecated[$propName] = $this->getDeprecatedData($docComment, $class, $propName);
             }


### PR DESCRIPTION
This was introduced in 1.5 so targetting that version.

## Issue
- https://github.com/silverstripe/silverstripe-config/issues/86