### PR TITLE
ENH Suppress deprecation warnings for inescapable config

### DIFF
--- a/src/Collections/MemoryConfigCollection.php
+++ b/src/Collections/MemoryConfigCollection.php
@@ -118,7 +118,13 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface
         $data = $deprecated['config'][strtolower($class)][$name] ?? [];
         if (!empty($data)) {
             if (class_exists(Deprecation::class)) {
-                Deprecation::notice($data['version'], $data['message'], Deprecation::SCOPE_CONFIG);
+                if (preg_match('/in a future major release\.?/', $data['message'])) {
+                    Deprecation::withSuppressedNotice(
+                        fn() => Deprecation::notice($data['version'], $data['message'], Deprecation::SCOPE_CONFIG)
+                    );
+                } else {
+                    Deprecation::notice($data['version'], $data['message'], Deprecation::SCOPE_CONFIG);
+                }
             } else {
                 user_error($data['message'], E_USER_DEPRECATED);
             }


### PR DESCRIPTION
Some config won't be avoidable until the next major release. Those should not be flooding peoples' logs with deprecation warnings.

## Issue

- https://github.com/silverstripe/silverstripe-config/issues/129