### PR TITLE
ENH PHP 8.5 Support

### DIFF
--- a/src/Transformer/PrivateStaticTransformer.php
+++ b/src/Transformer/PrivateStaticTransformer.php
@@ -82,7 +82,6 @@ class PrivateStaticTransformer implements TransformerInterface
 
             // Note that some non-config private statics may be assigned
             // un-serializable values. Detect these here
-            $prop->setAccessible(true);
             $value = $prop->getValue();
             if ($this->isConfigValue($value)) {
                 $classConfig[$prop->getName()] = $value;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.